### PR TITLE
dist: update package descriptions

### DIFF
--- a/openstack/Bareon/Bareon.spec.j2
+++ b/openstack/Bareon/Bareon.spec.j2
@@ -70,6 +70,7 @@ data, download operating system images and put these images on partitions.
 
 %package doc
 Summary:        Documentation for OpenStack bareon
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('oslosphinx') }}
 

--- a/openstack/Tempest/Tempest.spec.j2
+++ b/openstack/Tempest/Tempest.spec.j2
@@ -65,6 +65,7 @@ deployment.
 
 %package doc
 Summary:        Documentation for the OpenStack Integration Test Suite
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('oslosphinx') }}
 

--- a/openstack/aodhclient/aodhclient.spec.j2
+++ b/openstack/aodhclient/aodhclient.spec.j2
@@ -38,8 +38,8 @@ This is a client library for Aodh built on the Aodh API. It
 provides a Python API (the aodhclient module) and a command-line tool.
 
 %package doc
-Summary:        Documentation for OpenStack Aodh API Client
-Group:          Documentation
+Summary:        Documentation for the OpenStack Aodh API client
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('oslosphinx') }}
 

--- a/openstack/automaton/automaton.spec.j2
+++ b/openstack/automaton/automaton.spec.j2
@@ -2,7 +2,7 @@
 Name:           {{ py2name('automaton') }}
 Version:        1.12.0
 Release:        0
-Summary:        Friendly state machines for python
+Summary:        State machines for Python
 License:        {{ license('Apache-2.0') }}
 Group:          Development/Languages/Python
 Url:            https://launchpad.net/%{sname}
@@ -24,10 +24,11 @@ Requires:       {{ py2pkg('six') }}
 BuildArch:      noarch
 
 %description
-Friendly state machines for python.
+State machines for Python.
 
 %package doc
-Summary:        Documentation for the Automaton Library
+Summary:        Documentation for the Automaton library
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 

--- a/openstack/castellan/castellan.spec.j2
+++ b/openstack/castellan/castellan.spec.j2
@@ -35,13 +35,13 @@ Generic Key Manager interface for OpenStack.
 
 %package doc
 Summary:        Documentation for castellan
-Group:          Documentation
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 
 %description doc
 Castellan is a generic Key Manager interface for OpenStack.
-This package contains the documentation
+This package contains the documentation.
 
 %prep
 %autosetup -n %{sname}-%{version}

--- a/openstack/ceilometermiddleware/ceilometermiddleware.spec.j2
+++ b/openstack/ceilometermiddleware/ceilometermiddleware.spec.j2
@@ -33,7 +33,7 @@ event data generation to be consumed by Ceilometer.
 
 %package doc
 Summary:        Documentation for %{name}
-Group:          Documentation
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('oslosphinx') }}
 

--- a/openstack/cliff/cliff.spec.j2
+++ b/openstack/cliff/cliff.spec.j2
@@ -36,7 +36,7 @@ setuptools entry points to provide subcommands, output formatters, and
 other extensions.
 
 %package doc
-Summary:        %{summary} - Documentation
+Summary:        Documentation for the Command Line Interface Formulation Framework
 Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}

--- a/openstack/debtcollector/debtcollector.spec.j2
+++ b/openstack/debtcollector/debtcollector.spec.j2
@@ -35,7 +35,7 @@ future deprecations.
 
 %package doc
 Summary:        Documentation for %{name}
-Group:          Documentation
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 

--- a/openstack/django_openstack_auth/django_openstack_auth.spec.j2
+++ b/openstack/django_openstack_auth/django_openstack_auth.spec.j2
@@ -38,7 +38,7 @@ user against OpenStack's Keystone Identity API.
 
 %package doc
 Summary:        Documentation for %{name}
-Group:          Documentation
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 

--- a/openstack/glance_store/glance_store.spec.j2
+++ b/openstack/glance_store/glance_store.spec.j2
@@ -60,8 +60,8 @@ BuildArch:      noarch
 Glance store library.
 
 %package doc
-Summary:        Documentation for OpenStack Image Service Store Library
-Group:          Documentation
+Summary:        Documentation for the OpenStack Image Service Store library
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 BuildRequires:  {{ py2pkg('reno') }}

--- a/openstack/gnocchiclient/gnocchiclient.spec.j2
+++ b/openstack/gnocchiclient/gnocchiclient.spec.j2
@@ -42,8 +42,8 @@ This is a client library for Gnocchi built on the Gnocchi API. It
 provides a Python API (the gnocchiclient module) and a command-line tool.
 
 %package doc
-Summary:        Documentation for OpenStack Gnocchi API Client
-Group:          Documentation
+Summary:        Documentation for the OpenStack Gnocchi API client
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('oslosphinx') }}
 

--- a/openstack/karbor/karbor.spec.j2
+++ b/openstack/karbor/karbor.spec.j2
@@ -78,7 +78,7 @@ BuildRequires:  systemd
 %description
 Karbor is a Python implementation of the OpenStack
 (http://www.openstack.org) Application Data Protection API.
-.
+
 This package contains the karbor python libraries.
 
 %package -n     python-{{ pypi_name }}
@@ -130,15 +130,14 @@ This package contains the Karbor Python library.
 
 %if 0%{?with_doc}
 %package doc
-Summary:        Documentation for OpenStack Application Data Protection Service
-Group:          Documentation
+Summary:        Documentation for the OpenStack Application Data Protection Service
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('oslosphinx') }}
 
 %description doc
-OpenStack Karbor documentaion.
-.
-This package contains the documentation
+Karbor is a Python implementation of the OpenStack Application Data Protection API.
+This package contains the Karbor Python library.
 %endif
 
 %package api

--- a/openstack/keystone/keystone.spec.j2
+++ b/openstack/keystone/keystone.spec.j2
@@ -55,7 +55,7 @@ Requires(pre):  shadow-utils
 %description
 Keystone is a Python implementation of the OpenStack
 (http://www.openstack.org) identity service API.
-.
+
 This package contains the keystone python libraries.
 
 %package -n     python-{{ pypi_name }}
@@ -111,8 +111,8 @@ Keystone is a Python implementation of the OpenStack
 This package contains the Keystone Python library.
 
 %package doc
-Summary:        Documentation for OpenStack Identity Service
-Group:          Documentation
+Summary:        Documentation for the OpenStack Identity service
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('PasteDeploy') }}
 BuildRequires:  {{ py2pkg('Routes') }}
 BuildRequires:  {{ py2pkg('Sphinx') }}
@@ -136,9 +136,9 @@ BuildRequires:  {{ py2pkg('pysaml2') }}
 BuildRequires:  {{ py2pkg('python-memcached') }}
 
 %description doc
-OpenStack Keystone documentaion.
-.
-This package contains the documentation
+Keystone is a Python implementation of the OpenStack identity service API.
+
+This package contains the documentation.
 
 %prep
 %autosetup -p1 -n {{ pypi_name }}-{{upstream_version}}

--- a/openstack/keystoneauth1/keystoneauth1.spec.j2
+++ b/openstack/keystoneauth1/keystoneauth1.spec.j2
@@ -48,6 +48,7 @@ Tools for authenticating to an OpenStack-based cloud. These tools include:
 
 %package doc
 Summary:        Documentation for OpenStack authenticating tools
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 

--- a/openstack/keystonemiddleware/keystonemiddleware.spec.j2
+++ b/openstack/keystonemiddleware/keystonemiddleware.spec.j2
@@ -53,12 +53,13 @@ The most prominent module is keystonemiddleware.auth_token. This package
 does not expose any CLI or Python API features.
 
 %package doc
-Summary:        Documentation for Middleware for OpenStack Identity
+Summary:        Documentation for OpenStack Identity middleware
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 
 %description doc
-Documentation for Middleware for OpenStack Identity.
+Documentation for OpenStack Identity middleware.
 
 %prep
 %autosetup -p1 -n %{sname}-%{version}

--- a/openstack/masakari-monitors/masakari-monitors.spec.j2
+++ b/openstack/masakari-monitors/masakari-monitors.spec.j2
@@ -65,7 +65,8 @@ System package - %{name}
 Python package - %{python_pkg}
 
 %package        doc
-Summary:        Documentation for OpenStack Masakari Service
+Summary:        Documentation for the OpenStack Masakari service
+Group:          Documentation/HTML
 BuildRequires:  git
 BuildRequires:  {{ py2pkg('Tempest') }}
 BuildRequires:  {{ py2pkg('Sphinx') }}

--- a/openstack/masakari/masakari.spec.j2
+++ b/openstack/masakari/masakari.spec.j2
@@ -54,7 +54,8 @@ System package - %{name}
 Python package - python-%{sname}
 
 %package        doc
-Summary:        Documentation for OpenStack Masakari Service
+Summary:        Documentation for the OpenStack Masakari service
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Tempest') }}
 BuildRequires:  {{ py2pkg('WSME') }}
 BuildRequires:  {{ py2pkg('jsonschema') }}

--- a/openstack/microversion_parse/microversion_parse.spec.j2
+++ b/openstack/microversion_parse/microversion_parse.spec.j2
@@ -19,11 +19,12 @@ A simple parser for OpenStack microversion headers.
 
 %package doc
 Summary:        Documentation for OpenStack Microversion headers
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('oslosphinx') }}
 
 %description doc
-This package contains thedocumentation for OpenStack microversion
+This package contains the documentation for OpenStack microversion
 headers parsing library.
 
 %prep

--- a/openstack/mistral/mistral.spec.j2
+++ b/openstack/mistral/mistral.spec.j2
@@ -82,7 +82,8 @@ System package - %{name}
 Python package - python-{{ pypi_name }}
 
 %package        doc
-Summary:        Documentation for OpenStack Workflow Service
+Summary:        Documentation for the OpenStack Workflow service
+Group:          Documentation/HTML
 BuildRequires:  git
 BuildRequires:  {{ py2pkg('Tempest') }}
 BuildRequires:  {{ py2pkg('Sphinx') }}
@@ -98,9 +99,7 @@ BuildRequires:  {{ py2pkg('sphinxcontrib-pecanwsme') }}
 BuildRequires:  {{ py2pkg('yaql') }}
 
 %description    doc
-OpenStack Mistral documentaion.
-.
-This package contains the documentation
+This package contains the documentation for OpenStack Mistral.
 
 %package -n     python-{{ pypi_name }}
 Summary:        Mistral Python libraries
@@ -166,7 +165,7 @@ Mistral is a workflow service.
 Most business processes consist of multiple distinct interconnected steps that need to be executed in a particular order
 in a distributed environment. One can describe such process as a set of tasks and task relations and upload such description
 to Mistral so that it takes care of state management, correct execution order, parallelism, synchronization and high availability.
-.
+
 This package contains the Python libraries.
 
 %package        api
@@ -174,8 +173,8 @@ Summary:        OpenStack Mistral API service
 Requires:       %{name} = %{version}
 
 %description    api
-OpenStack rest API to the Mistral api.
-.
+OpenStack rest API to the Mistral API.
+
 This package contains the ReST API.
 
 %package        engine
@@ -184,7 +183,7 @@ Requires:       %{name} = %{version}
 
 %description    engine
 OpenStack Mistral Engine service.
-.
+
 This package contains the mistral engine, which is one of core services of mistral.
 
 %package        executor
@@ -193,7 +192,7 @@ Requires:       %{name} = %{version}
 
 %description    executor
 OpenStack Mistral Executor service.
-.
+
 This package contains the mistral executor, which is one of core services of mistral, and
 which the API servers will use.
 

--- a/openstack/mox3/mox3.spec.j2
+++ b/openstack/mox3/mox3.spec.j2
@@ -27,7 +27,7 @@ enhancements have been made. The library was tested on Python version
 
 %package doc
 Summary:        Documentation for %{name}
-Group:          Documentation
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 

--- a/openstack/neutron-lib/neutron-lib.spec.j2
+++ b/openstack/neutron-lib/neutron-lib.spec.j2
@@ -52,7 +52,7 @@ OpenStack Neutron library shared by all Neutron sub-projects.
 
 %package doc
 Summary:        OpenStack Neutron library documentation
-Group:          Documentation
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 BuildRequires:  {{ py2pkg('reno') }}

--- a/openstack/neutron/neutron.spec.j2
+++ b/openstack/neutron/neutron.spec.j2
@@ -226,15 +226,13 @@ SR-IOV network cards.
 
 %if 0%{?with_doc}
 %package doc
-Summary:        Documentation for OpenStack Networking Service
-Group:          Documentation
+Summary:        Documentation for the OpenStack Networking service
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('oslosphinx') }}
 
 %description doc
-OpenStack Neutron documentaion.
-
-This package contains the documentation
+This package contains the documentation for OpenStack Neutron.
 %endif
 
 %prep

--- a/openstack/nova/nova.spec.j2
+++ b/openstack/nova/nova.spec.j2
@@ -422,7 +422,7 @@ spice HTML5 console access service to Virtual Machines.
 %if 0%{?with_doc}
 %package doc
 Summary:        Documentation for OpenStack Compute
-Group:          Documentation
+Group:          Documentation/HTML
 BuildRequires:  graphviz
 BuildRequires:  {{ py2pkg('Babel') }}
 BuildRequires:  {{ py2pkg('MySQL-python') }}

--- a/openstack/openstack-macros/openstack-macros.spec.j2
+++ b/openstack/openstack-macros/openstack-macros.spec.j2
@@ -4,9 +4,9 @@
 Name:           openstack-macros
 Version:        2018.1.0
 Release:        0
-Summary:        OpenStack Packaging - RPM Macros
+Summary:        RPM macros for OpenStack packaging
 License:        {{ license('Apache-2.0') }}
-Group:          Development/Libraries/Python
+Group:          Development/Tools/Other
 Url:            https://wiki.openstack.org/wiki/Rpm-packaging
 Source0:        macros.openstack-common
 Source1:        macros.openstack-suse

--- a/openstack/openstacksdk/openstacksdk.spec.j2
+++ b/openstack/openstacksdk/openstacksdk.spec.j2
@@ -41,7 +41,7 @@ provide a consistent and complete set of interactions with OpenStack's
 many services, along with complete documentation, examples, and tools.
 
 %package doc
-Summary:        %{summary} - Documentation
+Summary:        Documentation for the OpenStack SDK
 Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('keystoneauth1') }}

--- a/openstack/os-apply-config/os-apply-config.spec.j2
+++ b/openstack/os-apply-config/os-apply-config.spec.j2
@@ -30,10 +30,11 @@ BuildRequires:  {{ py2pkg('testtools') }}
 %endif
 
 %description
-os-apply-config is a apply configuration from cloud metadata
+os-apply-config applies configuration from cloud metadata.
 
 %package doc
-Summary:        Documentation for OpenStack Os-apply-config configuration library
+Summary:        Documentation for the OpenStack Os-apply-config configuration library
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('oslosphinx') }}
 BuildRequires:  {{ py2pkg('reno') }}

--- a/openstack/os-brick/os-brick.spec.j2
+++ b/openstack/os-brick/os-brick.spec.j2
@@ -56,15 +56,13 @@ Features:
 - Removal of volumes from a host.
 
 %package doc
-Summary:        Documentation for OpenStack os-brick library
+Summary:        Documentation for the OpenStack os-brick library
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('oslosphinx') }}
 
 %description doc
 OpenStack Cinder brick library for managing local volume attaches.
-Features:
-- Discovery of volumes being attached to a host for many transport protocols.
-- Removal of volumes from a host.
 This package contains the documentation.
 
 %prep

--- a/openstack/os-client-config/os-client-config.spec.j2
+++ b/openstack/os-client-config/os-client-config.spec.j2
@@ -42,7 +42,8 @@ you don't have to know extra info to use OpenStack.
 
 %if %{with docs}
 %package doc
-Summary:        Documentation for OpenStack client configuration library
+Summary:        Documentation for the OpenStack client configuration library
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('oslosphinx') }}
 BuildRequires:  {{ py2pkg('reno') }}

--- a/openstack/os-service-types/os-service-types.spec.j2
+++ b/openstack/os-service-types/os-service-types.spec.j2
@@ -28,7 +28,8 @@ version of the data to use in case network access is for some reason not
 possible and local caching of the fetched data.
 
 %package doc
-Summary:        Documentation for OpenStack os-service-types library
+Summary:        Documentation for the OpenStack os-service-types library
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 

--- a/openstack/os-testr/os-testr.spec.j2
+++ b/openstack/os-testr/os-testr.spec.j2
@@ -28,8 +28,8 @@ A testr wrapper to provide functionality for OpenStack projects
 * Bugs: http://bugs.launchpad.net/os-testr
 
 %package doc
-Summary:        Documentation for the testr
-Group:          Documentation
+Summary:        Documentation for the testr wrapper
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('oslosphinx') }}
 

--- a/openstack/os-traits/os-traits.spec.j2
+++ b/openstack/os-traits/os-traits.spec.j2
@@ -30,8 +30,8 @@ OpenStack community to refer to a particular hardware, virtualization, storage,
 network, or device trait.
 
 %package doc
-Summary:        Documentation for OpenStack traits Library
-Group:          Documentation
+Summary:        Documentation for the OpenStack traits library
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('oslosphinx') }}
 

--- a/openstack/os-vif/os-vif.spec.j2
+++ b/openstack/os-vif/os-vif.spec.j2
@@ -43,14 +43,14 @@ Features:
 * Versioned objects that represent a virtual interface and its components
 
 %package doc
-Summary:        Documentation for a library for plugging and unplugging virtual interfaces in OpenStack
+Summary:        Documentation for OpenStack's virtual interface plugging library
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 BuildRequires:  {{ py2pkg('reno') }}
 
 %description doc
-Documentation for a library for plugging and unplugging virtual interfaces
-in OpenStack.
+Documentation for OpenStack's virtual interface plugging library.
 
 %prep
 %autosetup -n %{sname}-%{version}

--- a/openstack/os-win/os-win.spec.j2
+++ b/openstack/os-win/os-win.spec.j2
@@ -36,12 +36,12 @@ Requires:       {{ py2pkg('pbr') }}
 BuildArch:      noarch
 
 %description
-Library contains Windows / Hyper-V code commonly used in the OpenStack projects:
-nova, cinder, networking-hyperv.
+Library containing Windows / Hyper-V code commonly used in the
+OpenStack projects nova, cinder and networking-hyperv.
 
 %package doc
-Summary:        Documentation for OpenStack Windows/Hyper-V Library
-Group:          Documentation
+Summary:        Documentation for the OpenStack Windows/Hyper-V library
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 

--- a/openstack/os-xenapi/os-xenapi.spec.j2
+++ b/openstack/os-xenapi/os-xenapi.spec.j2
@@ -38,7 +38,8 @@ BuildArch:      noarch
 XenAPI library for OpenStack projects.
 
 %package doc
-Summary:        Documentation for OpenStack log library
+Summary:        Documentation for the OpenStack XenAPI library
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('oslosphinx') }}
 

--- a/openstack/osc-lib/osc-lib.spec.j2
+++ b/openstack/osc-lib/osc-lib.spec.j2
@@ -46,6 +46,7 @@ is a package of common support modules for writing OSC plugins.
 
 %package doc
 Summary:        Documentation for the OpenStack client library
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 

--- a/openstack/oslo.cache/oslo.cache.spec.j2
+++ b/openstack/oslo.cache/oslo.cache.spec.j2
@@ -37,6 +37,7 @@ backends such as Memcached.
 
 %package doc
 Summary:        Documentation for the OpenStack Oslo Cache library
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 

--- a/openstack/oslo.concurrency/oslo.concurrency.spec.j2
+++ b/openstack/oslo.concurrency/oslo.concurrency.spec.j2
@@ -39,7 +39,8 @@ multi-process applications using locking mechanisms and for running
 external processes.
 
 %package doc
-Summary:        Documentation for OpenStack concurrency library
+Summary:        Documentation for the OpenStack concurrency library
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 

--- a/openstack/oslo.config/oslo.config.spec.j2
+++ b/openstack/oslo.config/oslo.config.spec.j2
@@ -44,7 +44,8 @@ The oslo-config library is a command line and configuration file
 parsing library from the Oslo project.
 
 %package doc
-Summary:       Documentation for OpenStack common configuration library
+Summary:        Documentation for the OpenStack common configuration library
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 

--- a/openstack/oslo.context/oslo.context.spec.j2
+++ b/openstack/oslo.context/oslo.context.spec.j2
@@ -26,8 +26,8 @@ The request context is usually populated in the WSGI pipeline and
 used by various modules such as logging.
 
 %package doc
-Summary:        Documentation for OpenStack common context library
-Group:          Documentation
+Summary:        Documentation for the OpenStack common context library
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 

--- a/openstack/oslo.db/oslo.db.spec.j2
+++ b/openstack/oslo.db/oslo.db.spec.j2
@@ -53,7 +53,7 @@ to the different backends and helper utils.
 
 %package doc
 Summary:        Documentation for the Oslo database handling library
-Group:          Documentation
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 

--- a/openstack/oslo.i18n/oslo.i18n.spec.j2
+++ b/openstack/oslo.i18n/oslo.i18n.spec.j2
@@ -23,7 +23,8 @@ The oslo.i18n library contain utilities for working with internationalization
 or library.
 
 %package doc
-Summary:        Documentation for OpenStack i18n library
+Summary:        Documentation for the OpenStack i18n library
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 

--- a/openstack/oslo.log/oslo.log.spec.j2
+++ b/openstack/oslo.log/oslo.log.spec.j2
@@ -43,7 +43,8 @@ for all openstack projects.It also provides custom formatters, handlers and
 support for context specific logging (like resource id's etc).
 
 %package doc
-Summary:        Documentation for OpenStack log library
+Summary:        Documentation for the OpenStack log library
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 

--- a/openstack/oslo.messaging/oslo.messaging.spec.j2
+++ b/openstack/oslo.messaging/oslo.messaging.spec.j2
@@ -74,7 +74,8 @@ The Oslo messaging API supports RPC and notifications over a number
 of different messaging transports.
 
 %package doc
-Summary:        Documentation for OpenStack messaging library
+Summary:        Documentation for the OpenStack messaging library
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 

--- a/openstack/oslo.middleware/oslo.middleware.spec.j2
+++ b/openstack/oslo.middleware/oslo.middleware.spec.j2
@@ -43,7 +43,8 @@ with functionality like add/delete/modification of http headers and support
 for limiting size/connection etc.
 
 %package doc
-Summary:        Documentation for OpenStack middleware library
+Summary:        Documentation for the OpenStack middleware library
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 BuildRequires:  {{ py2pkg('reno') }}

--- a/openstack/oslo.policy/oslo.policy.spec.j2
+++ b/openstack/oslo.policy/oslo.policy.spec.j2
@@ -31,7 +31,7 @@ RBAC policy enforcement library for OpenStack.
 
 %package doc
 Summary:        Documentation for the Oslo Policy library
-Group:          Documentation
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 

--- a/openstack/oslo.privsep/oslo.privsep.spec.j2
+++ b/openstack/oslo.privsep/oslo.privsep.spec.j2
@@ -37,14 +37,15 @@ Requires:       {{ py2pkg('oslo.utils') }}
 BuildArch:      noarch
 
 %description
-OpenStack library for privilege separation
+OpenStack library for privilege separation.
 
 %package doc
 Summary:        oslo.privsep documentation
+Group:          Documentation/HTML
 Requires:       %{name} = %{version}
 
 %description doc
-Documentation for oslo.privsep
+Documentation for oslo.privsep.
 
 %prep
 %autosetup -n %{sname}-%{version}

--- a/openstack/oslo.reports/oslo.reports.spec.j2
+++ b/openstack/oslo.reports/oslo.reports.spec.j2
@@ -33,7 +33,8 @@ The project oslo.reports hosts a general purpose error report generation
 framework, known as the "guru meditation report".
 
 %package doc
-Summary:        Documentation for OpenStack reports library
+Summary:        Documentation for the OpenStack reports library
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 

--- a/openstack/oslo.rootwrap/oslo.rootwrap.spec.j2
+++ b/openstack/oslo.rootwrap/oslo.rootwrap.spec.j2
@@ -33,6 +33,7 @@ from OpenStack services.
 
 %package doc
 Summary:        Documentation for OpenStack %{sname}
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 BuildRequires:  {{ py2pkg('reno') }}

--- a/openstack/oslo.serialization/oslo.serialization.spec.j2
+++ b/openstack/oslo.serialization/oslo.serialization.spec.j2
@@ -28,7 +28,8 @@ The oslo.serialization library provides support for representing objects
 in transmittable and storable formats, such as Base64, JSON and MessagePack.
 
 %package doc
-Summary:        Documentation for OpenStack serialization library
+Summary:        Documentation for the OpenStack serialization library
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 

--- a/openstack/oslo.service/oslo.service.spec.j2
+++ b/openstack/oslo.service/oslo.service.spec.j2
@@ -49,7 +49,8 @@ utilities long-running applications might need for working with SSL or WSGI,
 performing periodic operations, interacting with systemd, etc.
 
 %package doc
-Summary:        Documentation for OpenStack service library
+Summary:        Documentation for the OpenStack service library
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 BuildRequires:  {{ py2pkg('reno') }}

--- a/openstack/oslo.utils/oslo.utils.spec.j2
+++ b/openstack/oslo.utils/oslo.utils.spec.j2
@@ -40,7 +40,8 @@ The oslo.utils library provides support for common utility type functions,
 such as encoding, exception handling, string manipulation, and time handling.
 
 %package doc
-Summary:        Documentation for OpenStack utils library
+Summary:        Documentation for the OpenStack utils library
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 

--- a/openstack/oslo.versionedobjects/oslo.versionedobjects.spec.j2
+++ b/openstack/oslo.versionedobjects/oslo.versionedobjects.spec.j2
@@ -45,7 +45,7 @@ used in RPC APIs, to ensure upgrades happen without spreading version dependent
 code across different services and projects.
 
 %package doc
-Summary:        osloversionedobjects library - Documentation
+Summary:        Documentation for the osloversionedobjects library
 Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}

--- a/openstack/oslo.vmware/oslo.vmware.spec.j2
+++ b/openstack/oslo.vmware/oslo.vmware.spec.j2
@@ -51,7 +51,8 @@ The Oslo VMware library offers session and API call management for VMware ESX/VC
 server.
 
 %package        doc
-Summary:        Documentation for OpenStack common VMware library
+Summary:        Documentation for the OpenStack common VMware library
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 Requires:       %{name} = %{version}

--- a/openstack/osprofiler/osprofiler.spec.j2
+++ b/openstack/osprofiler/osprofiler.spec.j2
@@ -42,6 +42,7 @@ reasons (for example in isolating cross-project performance issues).
 
 %package doc
 Summary:        Documentation for OSProfiler
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 

--- a/openstack/ovsdbapp/ovsdbapp.spec.j2
+++ b/openstack/ovsdbapp/ovsdbapp.spec.j2
@@ -31,7 +31,8 @@ Open_vSwitchs OVSDB protocol (https://tools.ietf.org/html/rfc7047). It wraps
 the Python 'ovs' and adds an event loop and friendly transactions.
 
 %package doc
-Summary:        Documentation for OpenStack log library
+Summary:        Documentation for the OpenStack log library
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('oslosphinx') }}
 

--- a/openstack/pbr/pbr.spec.j2
+++ b/openstack/pbr/pbr.spec.j2
@@ -28,7 +28,8 @@ different projects each with at least 3 active branches, it seems like a good
 time to make that code into a proper re-usable library.
 
 %package doc
-Summary:        Documentation for the PBR
+Summary:        Documentation for python-pbr
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('oslosphinx') }}
 

--- a/openstack/pycadf/pycadf.spec.j2
+++ b/openstack/pycadf/pycadf.spec.j2
@@ -28,6 +28,7 @@ DMTF Cloud Audit (CADF) data model
 
 %package doc
 Summary:        Documentation for the DMTF Cloud Audit (CADF) data model
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('oslosphinx') }}
 

--- a/openstack/pyghmi/pyghmi.spec.j2
+++ b/openstack/pyghmi/pyghmi.spec.j2
@@ -24,8 +24,8 @@ pyghmicons and pyghmiutil are example scripts to show how one may incorporate
 this library into python code
 
 %package doc
-Summary:        General Hardware Management Initiative (IPMI and others) -- Documentation
-Group:          Documentation
+Summary:        Documentation for the General Hardware Management Initiative (IPMI and others)
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 

--- a/openstack/pymod2pkg/pymod2pkg.spec.j2
+++ b/openstack/pymod2pkg/pymod2pkg.spec.j2
@@ -21,13 +21,14 @@ pymod2pkg is a simple python module for translating python module names to
 corresponding package names which is a common problem in the packaging world.
 
 %package doc
-Summary:        Documentation for python module name to package name map library
+Summary:        Documentation for pymod2pkg
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('oslosphinx') }}
 Requires:       %{name} = %{version}
 
 %description doc
-Documentation for python module name to package name map library.
+Documentation for OpenStack's package name <-> Python module name mapping library.
 
 %prep
 %autosetup -n %{sname}-%{version}

--- a/openstack/python-barbicanclient/python-barbicanclient.spec.j2
+++ b/openstack/python-barbicanclient/python-barbicanclient.spec.j2
@@ -40,8 +40,8 @@ command-line script (barbican).
 This package contains the Python 2.x module.
 
 %package doc
-Summary:        Documentation for OpenStack Key Management API Client
-Group:          Documentation
+Summary:        Documentation for the OpenStack Key Management API Client
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 

--- a/openstack/python-ceilometerclient/python-ceilometerclient.spec.j2
+++ b/openstack/python-ceilometerclient/python-ceilometerclient.spec.j2
@@ -42,8 +42,8 @@ provides a Python API (the ceilometerclient module) and a command-line tool
 (ceilometer).
 
 %package doc
-Summary:        Documentation for OpenStack Ceilometer API Client
-Group:          Documentation
+Summary:        Documentation for the OpenStack Ceilometer API Client
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('oslosphinx') }}
 

--- a/openstack/python-cinderclient/python-cinderclient.spec.j2
+++ b/openstack/python-cinderclient/python-cinderclient.spec.j2
@@ -42,8 +42,8 @@ Python API (the cinderclient module), and a command-line script (cinder).
 Each implements 100% of the OpenStack Cinder API.
 
 %package doc
-Summary:        Documentation for OpenStack Cinder API Client
-Group:          Documentation
+Summary:        Documentation for the OpenStack Cinder API Client
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 BuildRequires:  {{ py2pkg('reno') }}

--- a/openstack/python-cloudkittyclient/python-cloudkittyclient.spec.j2
+++ b/openstack/python-cloudkittyclient/python-cloudkittyclient.spec.j2
@@ -38,8 +38,8 @@ This is a client library for CloudKitty built on the CloudKitty API.
 It provides a Python API (the cloudkittyclient module).
 
 %package doc
-Summary:        Documentation for OpenStack Cloudkitty API client libary
-Group:          Documentation
+Summary:        Documentation for the OpenStack Cloudkitty API client libary
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('oslosphinx') }}
 

--- a/openstack/python-congressclient/python-congressclient.spec.j2
+++ b/openstack/python-congressclient/python-congressclient.spec.j2
@@ -47,8 +47,8 @@ state abides by the cloud operator's policies. Congress
 is designed to work with any policy and any cloud service.
 
 %package doc
-Summary:        Documentation for OpenStack Congress API client libary
-Group:          Documentation
+Summary:        Documentation for the OpenStack Congress API client libary
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 BuildRequires:  {{ py2pkg('reno') }}

--- a/openstack/python-designateclient/python-designateclient.spec.j2
+++ b/openstack/python-designateclient/python-designateclient.spec.j2
@@ -35,7 +35,7 @@ OpenStack DNS as a Service - Client
 
 %package doc
 Summary:        Documentation for the OpenStack DNS as a Service - Client
-Group:          Documentation
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 

--- a/openstack/python-dracclient/python-dracclient.spec.j2
+++ b/openstack/python-dracclient/python-dracclient.spec.j2
@@ -25,8 +25,8 @@ BuildArch:      noarch
 Library for managing machines with Dell iDRAC cards.
 
 %package doc
-Summary:        Documentation for OpenStack Drac API Client
-Group:          Documentation
+Summary:        Documentation for the OpenStack Drac API Client
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('oslosphinx') }}
 BuildRequires:  {{ py2pkg('reno') }}

--- a/openstack/python-freezerclient/python-freezerclient.spec.j2
+++ b/openstack/python-freezerclient/python-freezerclient.spec.j2
@@ -36,8 +36,8 @@ Client library for Freezer built on the Freezer API. It provides a Python API
 (the freezerclient module) and a command-line tool (freezer).
 
 %package doc
-Summary:        Documentation for OpenStack Freezer API client libary
-Group:          Documentation
+Summary:        Documentation for the OpenStack Freezer API client libary
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 

--- a/openstack/python-glanceclient/python-glanceclient.spec.j2
+++ b/openstack/python-glanceclient/python-glanceclient.spec.j2
@@ -43,8 +43,8 @@ glanceclient module), and a command-line script (glance). Each implements
 100% of the OpenStack Glance API.
 
 %package doc
-Summary:        Documentation for OpenStack Glance API Client
-Group:          Documentation
+Summary:        Documentation for the OpenStack Glance API Client
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 

--- a/openstack/python-glareclient/python-glareclient.spec.j2
+++ b/openstack/python-glareclient/python-glareclient.spec.j2
@@ -38,8 +38,8 @@ BuildArch:      noarch
 Python bindings to the Glare Artifact Repository
 
 %package doc
-Summary:        Documentation for OpenStack Glare API Client
-Group:          Documentation
+Summary:        Documentation for the OpenStack Glare API Client
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('oslosphinx') }}
 

--- a/openstack/python-heatclient/python-heatclient.spec.j2
+++ b/openstack/python-heatclient/python-heatclient.spec.j2
@@ -44,8 +44,8 @@ heatclient module), and a command-line script (heat). Each implements 100% of
 the OpenStack Heat API.
 
 %package doc
-Summary:        Documentation for OpenStack Heat API Client
-Group:          Documentation
+Summary:        Documentation for the OpenStack Heat API Client
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 

--- a/openstack/python-ironicclient/python-ironicclient.spec.j2
+++ b/openstack/python-ironicclient/python-ironicclient.spec.j2
@@ -50,8 +50,8 @@ This is a client for the OpenStack Ironic API. It provides a Python API (the
 ironicclient module) and a command-line interface (ironic).
 
 %package doc
-Summary:        Documentation for OpenStack Ironic API Client
-Group:          Documentation
+Summary:        Documentation for the OpenStack Ironic API Client
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 BuildRequires:  {{ py2pkg('reno') }}

--- a/openstack/python-k8sclient/python-k8sclient.spec.j2
+++ b/openstack/python-k8sclient/python-k8sclient.spec.j2
@@ -27,8 +27,8 @@ Client library for K8s built on the K8s API. It provides a Python API
 (the k8sclient module) and a command-line tool (k8s).
 
 %package doc
-Summary:        Documentation for OpenStack K8s API client libary
-Group:          Documentation
+Summary:        Documentation for the OpenStack K8s API client libary
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('oslosphinx') }}
 

--- a/openstack/python-karborclient/python-karborclient.spec.j2
+++ b/openstack/python-karborclient/python-karborclient.spec.j2
@@ -46,8 +46,8 @@ This is a client for the OpenStack Karbor API. It provides a Python API (the
 karborclient module) and a command-line interface (Karbor).
 
 %package doc
-Summary:        Documentation for OpenStack Karbor API Client
-Group:          Documentation
+Summary:        Documentation for the OpenStack Karbor API Client
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 BuildRequires:  {{ py2pkg('reno') }}

--- a/openstack/python-keystoneclient/python-keystoneclient.spec.j2
+++ b/openstack/python-keystoneclient/python-keystoneclient.spec.j2
@@ -43,8 +43,8 @@ BuildArch:      noarch
 Client library for interacting with Openstack Identity API.
 
 %package doc
-Summary:        Documentation for OpenStack Identity API Client
-Group:          Documentation
+Summary:        Documentation for the OpenStack Identity API Client
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 

--- a/openstack/python-magnumclient/python-magnumclient.spec.j2
+++ b/openstack/python-magnumclient/python-magnumclient.spec.j2
@@ -50,8 +50,8 @@ Client library for Magnum built on the Magnum API. It provides a Python API
 (the magnumclient module) and a command-line tool (magnum).
 
 %package doc
-Summary:        Documentation for OpenStack Magnum API client libary
-Group:          Documentation
+Summary:        Documentation for the OpenStack Magnum API client libary
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 

--- a/openstack/python-manilaclient/python-manilaclient.spec.j2
+++ b/openstack/python-manilaclient/python-manilaclient.spec.j2
@@ -34,8 +34,8 @@ Client library and command line utility for interacting with Openstack
 Share API.
 
 %package doc
-Summary:        Documentation for OpenStack Share API Client
-Group:          Documentation
+Summary:        Documentation for the OpenStack Share API Client
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 

--- a/openstack/python-masakariclient/python-masakariclient.spec.j2
+++ b/openstack/python-masakariclient/python-masakariclient.spec.j2
@@ -34,7 +34,7 @@ Client library for Masakari built on the Masakari API. It provides a Python API
 (the masakariclient module) and a command-line tool (masakari).
 
 %package doc
-Summary:        Documentation for OpenStack Masakari API client libary
+Summary:        Documentation for the OpenStack Masakari API client libary
 Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('oslosphinx') }}

--- a/openstack/python-mistralclient/python-mistralclient.spec.j2
+++ b/openstack/python-mistralclient/python-mistralclient.spec.j2
@@ -38,8 +38,8 @@ Client library for Mistral built on the Mistral API. It provides a Python API
 (the mistralclient module) and a command-line tool (mistral).
 
 %package doc
-Summary:        Documentation for OpenStack Mistral API client libary
-Group:          Documentation
+Summary:        Documentation for the OpenStack Mistral API client libary
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 

--- a/openstack/python-mistralclient/python-mistralclient.spec.j2
+++ b/openstack/python-mistralclient/python-mistralclient.spec.j2
@@ -76,7 +76,4 @@ PYTHONPATH=. nosetests mistralclient/tests/unit
 %{_bindir}/mistral
 %{_mandir}/man1/mistral_client.1.*
 
-%files doc
-%license LICENSE
-
 %changelog

--- a/openstack/python-muranoclient/python-muranoclient.spec.j2
+++ b/openstack/python-muranoclient/python-muranoclient.spec.j2
@@ -50,8 +50,8 @@ Client library for Murano built on the Murano API. It provides a Python API
 (the muranoclient module) and a command-line tool (murano).
 
 %package doc
-Summary:        Documentation for OpenStack Magnum API client libary
-Group:          Documentation
+Summary:        Documentation for the OpenStack Magnum API client libary
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 BuildRequires:  {{ py2pkg('reno') }}

--- a/openstack/python-neutronclient/python-neutronclient.spec.j2
+++ b/openstack/python-neutronclient/python-neutronclient.spec.j2
@@ -53,8 +53,8 @@ Client library and command line utility for interacting with OpenStack
 Neutron's API.
 
 %package doc
-Summary:        Documentation for OpenStack Neutron API Client
-Group:          Documentation
+Summary:        Documentation for the OpenStack Neutron API client
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 BuildRequires:  {{ py2pkg('reno') }}

--- a/openstack/python-novaclient/python-novaclient.spec.j2
+++ b/openstack/python-novaclient/python-novaclient.spec.j2
@@ -44,8 +44,8 @@ novaclient module), and a command-line script (nova). Each implements 100% of
 the OpenStack Nova API.
 
 %package doc
-Summary:        Documentation for OpenStack Nova API Client
-Group:          Documentation
+Summary:        Documentation for the OpenStack Nova API client
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 BuildRequires:  {{ py2pkg('reno') }}

--- a/openstack/python-oneviewclient/python-oneviewclient.spec.j2
+++ b/openstack/python-oneviewclient/python-oneviewclient.spec.j2
@@ -28,8 +28,8 @@ Client library for Oneview built on the Oneview API. It provides a Python API
 (the oneviewclient module) and a command-line tool (oneview).
 
 %package doc
-Summary:        Documentation for OpenStack Oneview API client libary
-Group:          Documentation
+Summary:        Documentation for the OpenStack Oneview API client libary
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('oslosphinx') }}
 

--- a/openstack/python-openstackclient/python-openstackclient.spec.j2
+++ b/openstack/python-openstackclient/python-openstackclient.spec.j2
@@ -48,8 +48,8 @@ It is a thin wrapper to the stock python-*client modules that implement the
 actual REST API client actions.
 
 %package doc
-Summary:        Documentation for OpenStack Command-line Client
-Group:          Documentation
+Summary:        Documentation for the OpenStack command-line client
+Group:          Documentation/HTML
 # Some clients are commented out, since they have not been built yet
 # TODO(jpena): uncomment them to enable their sections in the documentation
 BuildRequires:  {{ py2pkg('Sphinx') }}

--- a/openstack/python-saharaclient/python-saharaclient.spec.j2
+++ b/openstack/python-saharaclient/python-saharaclient.spec.j2
@@ -41,8 +41,8 @@ BuildArch:      noarch
 Python client library for interacting with OpenStack Sahara API.
 
 %package doc
-Summary:        Documentation for Client library for OpenStack Sahara API
-Group:          Documentation
+Summary:        Documentation for the OpenStack Sahara API client library
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 

--- a/openstack/python-scciclient/python-scciclient.spec.j2
+++ b/openstack/python-scciclient/python-scciclient.spec.j2
@@ -28,8 +28,8 @@ Client library for Scci built on the Scci API. It provides a Python API
 (the scciclient module) and a command-line tool (scci).
 
 %package doc
-Summary:        Documentation for OpenStack Scci API client libary
-Group:          Documentation
+Summary:        Documentation for the OpenStack Scci API client libary
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('oslosphinx') }}
 

--- a/openstack/python-senlinclient/python-senlinclient.spec.j2
+++ b/openstack/python-senlinclient/python-senlinclient.spec.j2
@@ -54,8 +54,8 @@ This is a client for the OpenStack Senlin API. It provides a Python API (the
 senlinclient module) and a command-line interface (senlin).
 
 %package doc
-Summary:        Documentation for OpenStack Senlin API Client
-Group:          Documentation
+Summary:        Documentation for the OpenStack Senlin API client
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 BuildRequires:  {{ py2pkg('reno') }}

--- a/openstack/python-solumclient/python-solumclient.spec.j2
+++ b/openstack/python-solumclient/python-solumclient.spec.j2
@@ -49,8 +49,8 @@ Client library for Solum built on the Solum API. It provides a Python API
 (the solumclient module) and a command-line tool (solum).
 
 %package doc
-Summary:        Documentation for OpenStack Solum API client libary
-Group:          Documentation
+Summary:        Documentation for the OpenStack Solum API client libary
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 

--- a/openstack/python-swiftclient/python-swiftclient.spec.j2
+++ b/openstack/python-swiftclient/python-swiftclient.spec.j2
@@ -25,7 +25,7 @@ This is a python client for the Swift API. There's a Python API (the
 swiftclient module), and a command-line script (swift).
 
 %package doc
-Summary:        %{summary} - Documentation
+Summary:        Documentation for the OpenStack Object Storage API client
 Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('futures') }}

--- a/openstack/python-tackerclient/python-tackerclient.spec.j2
+++ b/openstack/python-tackerclient/python-tackerclient.spec.j2
@@ -39,8 +39,8 @@ BuildArch:      noarch
 OpenStack tacker client
 
 %package doc
-Summary:        Documentation for OpenStack tacker client
-Group:          Documentation
+Summary:        Documentation for the OpenStack tacker client
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('oslosphinx') }}
 BuildRequires:  {{ py2pkg('reno') }}

--- a/openstack/python-tripleoclient/python-tripleoclient.spec.j2
+++ b/openstack/python-tripleoclient/python-tripleoclient.spec.j2
@@ -43,8 +43,8 @@ python-tripleoclient is a Python plugin to OpenstackClient
 for TripleO.
 
 %package doc
-Summary:        Documentation for OpenstackClient plugin for tripleoclient
-Group:          Documentation
+Summary:        Documentation for the OpenstackClient plugin for tripleoclient
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('oslosphinx') }}
 

--- a/openstack/python-troveclient/python-troveclient.spec.j2
+++ b/openstack/python-troveclient/python-troveclient.spec.j2
@@ -45,8 +45,8 @@ troveclient module), and a command-line script (trove). Each
 implements 100% (or less ;) ) of the Trove API.
 
 %package doc
-Summary:        Documentation for OpenStack DBaaS API.
-Group:          Documentation
+Summary:        Documentation for the OpenStack DBaaS API
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 

--- a/openstack/python-watcherclient/python-watcherclient.spec.j2
+++ b/openstack/python-watcherclient/python-watcherclient.spec.j2
@@ -42,8 +42,8 @@ Client library for Watcher built on the Watcher API. It provides a Python API
 (the watcherclient module) and a command-line tool (watcher).
 
 %package doc
-Summary:        Documentation for OpenStack Watcher API client libary
-Group:          Documentation
+Summary:        Documentation for the OpenStack Watcher API client libary
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 

--- a/openstack/python-zaqarclient/python-zaqarclient.spec.j2
+++ b/openstack/python-zaqarclient/python-zaqarclient.spec.j2
@@ -44,8 +44,8 @@ BuildArch:      noarch
 Python client to Zaqar Queueing API.
 
 %package doc
-Summary:        Documentation for OpenStack Zaqar Queueing API
-Group:          Documentation
+Summary:        Documentation for the OpenStack Zaqar Queueing API
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 

--- a/openstack/renderspec/renderspec.spec.j2
+++ b/openstack/renderspec/renderspec.spec.j2
@@ -24,6 +24,7 @@ and follow their policies and processes.
 
 %package doc
 Summary:        Documentation for the renderspec utility
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('oslosphinx') }}
 Requires:       %{name} = %{version}

--- a/openstack/stevedore/stevedore.spec.j2
+++ b/openstack/stevedore/stevedore.spec.j2
@@ -33,7 +33,7 @@ dynamically loaded extensions.
 
 %package doc
 Summary:        Documentation for %{name}
-Group:          Documentation
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 
 %description doc

--- a/openstack/taskflow/taskflow.spec.j2
+++ b/openstack/taskflow/taskflow.spec.j2
@@ -65,7 +65,7 @@ different backends to be used with OpenStack projects.
 
 %package doc
 Summary:        Documentation for Taskflow
-Group:          Documentation
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 

--- a/openstack/tooz/tooz.spec.j2
+++ b/openstack/tooz/tooz.spec.j2
@@ -45,7 +45,7 @@ a coordination API helping developers to build distributed applications.
 
 %package doc
 Summary:        Documentation for %{name}
-Group:          Documentation
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 

--- a/openstack/tripleo-common/tripleo-common.spec.j2
+++ b/openstack/tripleo-common/tripleo-common.spec.j2
@@ -54,8 +54,8 @@ BuildArch:      noarch
 Python library for code used by TripleO projects.
 
 %package doc
-Summary:        Documentation for Python library for code used by TripleO projects
-Group:          Documentation
+Summary:        Documentation for tripleo-common
+Group:          Documentation/HTML
 BuildRequires:  {{ py2pkg('Sphinx') }}
 BuildRequires:  {{ py2pkg('openstackdocstheme') }}
 


### PR DESCRIPTION
* RPM groups for documentation packages should be Documentation,
  not inherit Development/Languages/Python.
* Resolve grammar issues relating to missing "the" words.
* Replace some silly-looking descriptions that contain multiple
  chained prepositions ("documentation for library for ...")
* Throw out pointless dot-on-a-single-line. (/\n\.\n/ matches)