### PR TITLE
Patch to fix certificate handling in monasca-ui (bsc#1081840)

### DIFF
--- a/openstack/monasca-ui/monasca-ui.spec.j2
+++ b/openstack/monasca-ui/monasca-ui.spec.j2
@@ -18,6 +18,8 @@ License:        {{ license('Apache-2.0') }}
 Group:          Development/Languages/Python
 Url:            https://wiki.openstack.org/wiki/Monasca
 Source0:        {{ source|basename }}
+# PATCH-FIX-UPSTREAM 0001-Fixed-the-problem-for-SSL-certificate-access-failure.patch -- https://review.openstack.org/#/c/548103/
+Patch0:         0001-Fixed-the-problem-for-SSL-certificate-access-failure.patch
 Patch1:         allow-raw-grafana-links.patch
 Patch2:         drilldown-dimensions.patch
 BuildRequires:  fdupes


### PR DESCRIPTION
Patch in a fix for the certificate handling in the monasca-ui-plugin
Upstream request at: https://review.openstack.org/#/c/548103/
bugzilla issue: https://bugzilla.suse.com/show_bug.cgi?id=1081840
related (required) OBS SR: https://build.opensuse.org/request/show/581445
