### PR TITLE
Enables freezer api audit logging (bsc#1088165)

### DIFF
--- a/openstack/freezer-api/freezer-api.spec.j2
+++ b/openstack/freezer-api/freezer-api.spec.j2
@@ -29,6 +29,7 @@ BuildRequires:  {{ py2pkg('oslo.context') }}
 BuildRequires:  {{ py2pkg('oslo.db') }}
 BuildRequires:  {{ py2pkg('oslo.i18n') }}
 BuildRequires:  {{ py2pkg('oslo.log') }}
+BuildRequires:  {{ py2pkg('oslo.messaging') }}
 BuildRequires:  {{ py2pkg('oslo.middleware') }}
 BuildRequires:  {{ py2pkg('oslo.policy') }}
 BuildRequires:  {{ py2pkg('reno') }}
@@ -69,6 +70,7 @@ Requires:       {{ py2pkg('oslo.context') }}
 Requires:       {{ py2pkg('oslo.db') }}
 Requires:       {{ py2pkg('oslo.i18n') }}
 Requires:       {{ py2pkg('oslo.log') }}
+Requires:       {{ py2pkg('oslo.messaging') }}
 Requires:       {{ py2pkg('oslo.middleware') }}
 Requires:       {{ py2pkg('oslo.policy') }}
 Requires:       {{ py2pkg('six') }}


### PR DESCRIPTION
Enables freezer api audit logging by adding the oslo.messaging module
to the freezer venv.