### PR TITLE
Octavia: removed tempest test entry point

### DIFF
--- a/openstack/octavia-lib/0002-remove-tempest-entry-point.patch
+++ b/openstack/octavia-lib/0002-remove-tempest-entry-point.patch
@@ -1,0 +1,25 @@
+diff -ruN octavia-3.1.1.dev5/octavia.egg-info/entry_points.txt octavia-3.1.1.dev5.new/octavia.egg-info/entry_points.txt
+--- ./octavia.egg-info/entry_points.txt	2019-05-14 03:56:52.000000000 +0200
++++ ./octavia.egg-info/entry_points.txt	2019-05-28 12:35:04.088462256 +0200
+@@ -72,9 +72,6 @@
+ [oslo.policy.policies]
+ octavia = octavia.policies:list_rules
+ 
+-[tempest.test_plugins]
+-octavia = octavia.tests.tempest.plugin:OctaviaTempestPlugin
+-
+ [wsgi_scripts]
+ octavia-wsgi = octavia.api.app:setup_app
+ 
+diff -ruN octavia-3.1.1.dev5/setup.cfg octavia-3.1.1.dev5.new/setup.cfg
+--- ./setup.cfg	2019-05-14 03:56:52.000000000 +0200
++++ ./setup.cfg	2019-05-28 12:35:51.780839403 +0200
+@@ -96,8 +96,6 @@
+ 	hot_plug_plugin = octavia.controller.worker.controller_worker:ControllerWorker
+ oslo.config.opts = 
+ 	octavia = octavia.opts:list_opts
+-tempest.test_plugins = 
+-	octavia = octavia.tests.tempest.plugin:OctaviaTempestPlugin
+ oslo.policy.policies = 
+ 	octavia = octavia.policies:list_rules
+ oslo.policy.enforcer = 

--- a/openstack/octavia-lib/octavia-lib.spec.j2
+++ b/openstack/octavia-lib/octavia-lib.spec.j2
@@ -13,6 +13,7 @@ URL:            https://git.openstack.org/cgit/openstack/octavia-lib
 Source0:        {{ source }}
 # https://review.openstack.org/644874
 Patch0:         0001-Do-not-install-README.rst-and-LICENSE.patch
+Patch1:         0002-remove-tempest-entry-point.patch
 BuildRequires:  openstack-macros
 BuildRequires:  {{ py2pkg('devel', py_versions=['py2', 'py3']) }}
 BuildRequires:  {{ py2pkg('mock', py_versions=['py2', 'py3']) }}


### PR DESCRIPTION
Tempest is failing when octavia is intalled.

Could not load 'octavia': No module named octavia_tempest_plugin
No module named octavia_tempest_plugin

There is an entry point pointing to the tests of the package
openstack-octavia-test. These tests are replaced by the ones in the
package python-octavia-tempest-plugin